### PR TITLE
Update mj_renderer.py

### DIFF
--- a/src/physics_simulator/simulator/mj_wrapper/mj_renderer.py
+++ b/src/physics_simulator/simulator/mj_wrapper/mj_renderer.py
@@ -38,6 +38,8 @@ if os.environ.get("MUJOCO_GL", None) not in ["osmesa", "glx"]:
     # option for rendering
     if _SYSTEM == "Darwin":
         os.environ["MUJOCO_GL"] = "cgl"
+    elif _SYSTEM == "Windows":
+        os.environ["MUJOCO_GL"] = "wgl"
     else:
         os.environ["MUJOCO_GL"] = "egl"
 _MUJOCO_GL = os.environ.get("MUJOCO_GL", "").lower().strip()


### PR DESCRIPTION
The code in mj_renderer requires `os.environ["MUJOCO_GL"] = "wgl"` if `_SYSTEM="Windows"`. But when setting the environ variables only runs checks for whether` _SYSTEM == "Darwin"`, and otherwise sets `os.environ["MUJOCO_GL"] = "egl"` (for Linux distros). Adding `elif _SYSTEM = "Windows": os.environ["MUJOCO_GL"]="wgl"` fixes this.